### PR TITLE
Update collector-scc.yaml

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector-scc.yaml
@@ -20,7 +20,7 @@ fsGroup:
   type: RunAsAny
 groups: []
 priority: 0
-readOnlyRootFilesystem: true
+readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:


### PR DESCRIPTION
As this scc is based on scc privileged, when it is used by a serviceaccount, it runs as root but since readOnlyRootFilesystem: true, it prevents access to files/folders owned by user root.

readOnlyRootFilesystem: true in this scc has caused problems during the upgrades on openshift, because, the version job pod created by CVO, sometimes uses this scc and is unable to remove folders/files owned by user root.

List of related issues:- 
https://access.redhat.com/solutions/5911951
https://access.redhat.com/solutions/6985485
https://issues.redhat.com/browse/OTA-680
https://github.com/openshift/cluster-version-operator/pull/824

## Description

A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
